### PR TITLE
fix: Solid.js 1.0 link

### DIFF
--- a/data/2021.ts
+++ b/data/2021.ts
@@ -40,7 +40,7 @@ export default {
         {
             date: '2022-06-28',
             title: 'Solid.js 1.0 released',
-            link: 'https://github.com/vercel/next.js/releases/tag/v11.0.0',
+            link: 'https://github.com/solidjs/solid/releases/tag/v1.0.0',
             icon: 'solid'
         },
         {


### PR DESCRIPTION
Dear maintainer.  
I discovered that the link for Solid.js 1.0 was incorrectly pointing to Node.js. I made changes to point it to the right repository.  
Please take a look, thanks.